### PR TITLE
Make Accounts attributes public

### DIFF
--- a/Sources/Solita/RenderAccount.swift
+++ b/Sources/Solita/RenderAccount.swift
@@ -17,7 +17,7 @@ func colonSeparatedTypedField(
     field: AccountResolvedField,
     prefix:String=""
 ) -> String {
-    return "\(readOnly ? "let" : "var") \(prefix)\(field.name): \(field.swiftType)"
+    return "\(prefix) \(readOnly ? "let" : "var") \(field.name): \(field.swiftType)"
 }
 
 class AccountRenderer {
@@ -150,7 +150,7 @@ class AccountRenderer {
 * @category Accounts
 * @category generated
 */
-protocol \(self.accountDataArgsTypeName) {
+public protocol \(self.accountDataArgsTypeName) {
     \(renderedDiscriminator)
     \(renderedFields)
 }
@@ -298,7 +298,7 @@ static func getMinimumBalanceForRentExemption(
             .joined(separator: ",\n        ")
         
         let interfaceRequiredFields = editablefields
-            .map{ colonSeparatedTypedField(readOnly: true, field: $0) }
+            .map{ colonSeparatedTypedField(readOnly: true, field: $0, prefix: "public") }
             .map{ "\($0)" }
             .joined(separator: "\n  ")
         


### PR DESCRIPTION
- Makes structs from accounts implementation have an initialize from the public.
- Makes protocol public

Example :

```
public protocol AuctionhouseArgs {
      var auctionHouseDiscriminator: [UInt8] { get }
}

public struct Auctionhouse: AuctionhouseArgs {
    public let auctionHouseDiscriminator: [UInt8]
    ...
}
```

This allows:

`Auctionhouse(auctionHouseDiscriminator: auctionHouseDiscriminator)`