### PR TITLE
Fix hashing algorithm for discriminators

### DIFF
--- a/Sources/Solita/Util/Util.swift
+++ b/Sources/Solita/Util/Util.swift
@@ -99,12 +99,11 @@ func instructionDiscriminator(name: String) -> Data {
 
 func sighash(nameSpace: String, ixName: String) -> Data {
     let name = snakeCased(string: ixName)
-    let preimage = "\(nameSpace):\(name)"
-    var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-    let data = preimage.data(using: .utf8)!
-    data.withUnsafeBytes {
-        _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
-    }
+    let preimage = Data("\(nameSpace):\(name)".bytes) as NSData
+    let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
+    var hash = [UInt8](repeating: 0, count: digestLength)
+    CC_SHA256(preimage.bytes, UInt32(preimage.length), &hash)
+    let data = Data(NSData(bytes: hash, length: digestLength))
     return data.subdata(in: 0..<8)
 }
 

--- a/Tests/SolitaTests/Data/TestDataProvider.swift
+++ b/Tests/SolitaTests/Data/TestDataProvider.swift
@@ -1,0 +1,33 @@
+//
+//  TestDataProvider.swift
+//  
+//
+//  Created by Michael J. Huber Jr. on 10/24/22.
+//
+
+import Foundation
+@testable import Solita
+
+struct TestDataProvider {
+    static let serumMultisigJson = stubbedResponse("serum_multisig")
+    static let auctionHouseJson = stubbedResponse("action_house")
+    static let candyMachineJson = stubbedResponse("candy_machine")
+    static let fanoutJson = stubbedResponse("fanout")
+    static let featDataEnum = stubbedResponse("feat-data-enum")
+
+    static let discriminatorInstruction = InstructionDiscriminator(
+        ix: IdlInstruction(name: "createAuctionHouse", accounts: [], args: []),
+        fieldName: "createAuctionHouse",
+        typeMapper: TypeMapper()
+    )
+    static let expectedDiscriminatorRenderValue = "[221, 66, 242, 159, 249, 206, 134, 241] as [UInt8]"
+    static let expectedDiscriminatorFieldName = "createAuctionHouse"
+    static let expectedDiscriminatorRenderType = "[UInt8] /* size: 8 */"
+
+    private static func stubbedResponse(_ filename: String) -> Data {
+        let thisSourceFile = URL(fileURLWithPath: #file)
+        let thisDirectory = thisSourceFile.deletingLastPathComponent()
+        let resourceURL = thisDirectory.appendingPathComponent("../Resources/\(filename).json")
+        return try! Data(contentsOf: resourceURL)
+    }
+}

--- a/Tests/SolitaTests/IdlTests.swift
+++ b/Tests/SolitaTests/IdlTests.swift
@@ -8,7 +8,7 @@ final class IdlTests: XCTestCase {
     }
     
     func testSerumMultisigJsonParsedSuccess() {
-        let json = stubbedResponse("serum_multisig")
+        let json = TestDataProvider.serumMultisigJson
         let idl = try! getDencoder().decode(Idl.self, from: json)
         XCTAssertEqual(idl.name, "serum_multisig")
         XCTAssertEqual(idl.instructions.first!.name, "createMultisig")
@@ -23,7 +23,7 @@ final class IdlTests: XCTestCase {
     }
     
     func testActionHouseJsonParsedSuccess() {
-        let json = stubbedResponse("action_house")
+        let json = TestDataProvider.auctionHouseJson
         let idl = try! getDencoder().decode(Idl.self, from: json)
         XCTAssertEqual(idl.instructions.count, 28)
         XCTAssertEqual(idl.accounts!.count, 5)
@@ -34,7 +34,7 @@ final class IdlTests: XCTestCase {
     }
     
     func testCandyMachineJsonParsedSuccess() {
-        let json = stubbedResponse("candy_machine")
+        let json = TestDataProvider.candyMachineJson
         let idl = try! getDencoder().decode(Idl.self, from: json)
         XCTAssertEqual(idl.instructions.count, 9)
         XCTAssertEqual(idl.accounts!.count, 2)
@@ -42,12 +42,4 @@ final class IdlTests: XCTestCase {
         XCTAssertEqual(idl.errors!.count, 36)
         XCTAssertEqual(idl.name, "candy_machine")
     }
-}
-
-func stubbedResponse(_ filename: String) -> Data {
-    @objc class FeelitTests: NSObject { }
-    let thisSourceFile = URL(fileURLWithPath: #file)
-    let thisDirectory = thisSourceFile.deletingLastPathComponent()
-    let resourceURL = thisDirectory.appendingPathComponent("Resources/\(filename).json")
-    return try! Data(contentsOf: resourceURL)
 }

--- a/Tests/SolitaTests/InstructionDiscriminatorTests.swift
+++ b/Tests/SolitaTests/InstructionDiscriminatorTests.swift
@@ -1,0 +1,26 @@
+//
+//  InstructionDiscriminatorTests.swift
+//  
+//
+//  Created by Michael J. Huber Jr. on 10/24/22.
+//
+
+import XCTest
+@testable import Solita
+
+final class InstructionDiscriminatorTests: XCTestCase {
+    func testInstructionDiscriminatorRenderValue() {
+        let discriminatorInstruction = TestDataProvider.discriminatorInstruction
+        XCTAssertEqual(discriminatorInstruction.renderValue(), TestDataProvider.expectedDiscriminatorRenderValue)
+    }
+
+    func testInstructionDiscriminatorField() {
+        let discriminatorInstruction = TestDataProvider.discriminatorInstruction
+        XCTAssertEqual(discriminatorInstruction.getField().name, TestDataProvider.expectedDiscriminatorFieldName)
+    }
+
+    func testInstructionDiscriminatorRenderType() {
+        let discriminatorInstruction = TestDataProvider.discriminatorInstruction
+        XCTAssertEqual(discriminatorInstruction.renderType(), TestDataProvider.expectedDiscriminatorRenderType)
+    }
+}

--- a/Tests/SolitaTests/SolitaTests.swift
+++ b/Tests/SolitaTests/SolitaTests.swift
@@ -9,31 +9,31 @@ final class SolitaTests: XCTestCase {
     }
     
     func testSerumMultisig() {
-        let json = stubbedResponse("serum_multisig")
+        let json = TestDataProvider.serumMultisigJson
         let idl = try! getDencoder().decode(Idl.self, from: json)
         Solita(idl: idl).renderAndWriteTo(outputDir: Path.current.string)
     }
     
     func testActionHouse() {
-        let json = stubbedResponse("action_house")
+        let json = TestDataProvider.auctionHouseJson
         let idl = try! getDencoder().decode(Idl.self, from: json)
         Solita(idl: idl).renderAndWriteTo(outputDir: Path.current.string)
     }
     
     func testCandyMachine() {
-        let json = stubbedResponse("candy_machine")
+        let json = TestDataProvider.candyMachineJson
         let idl = try! getDencoder().decode(Idl.self, from: json)
         Solita(idl: idl).renderAndWriteTo(outputDir: Path.current.string)
     }
     
     func testFanout() {
-        let json = stubbedResponse("fanout")
+        let json = TestDataProvider.fanoutJson
         let idl = try! getDencoder().decode(Idl.self, from: json)
         Solita(idl: idl).renderAndWriteTo(outputDir: Path.current.string)
     }
     
     func testDataEnum() {
-        let json = stubbedResponse("feat-data-enum")
+        let json = TestDataProvider.featDataEnum
         let idl = try! getDencoder().decode(Idl.self, from: json)
         Solita(idl: idl).renderAndWriteTo(outputDir: Path.current.string)
     }


### PR DESCRIPTION
Our previous hashing algorithm was setting every discriminator to the same value and ignoring the discriminator name completely.

This provides a fix using methods in `CommonCrypto`, but can be achieved very elegantly when we move to iOS 13 and can import Apple's `CryptoKit`.