### PR TITLE
Add suppor for optional accounts and defaultOptionalAccounts

### DIFF
--- a/Sources/Solita/Idl.swift
+++ b/Sources/Solita/Idl.swift
@@ -61,6 +61,8 @@ public struct IdlInstruction: Decodable {
     let name: String
     let accounts: [IdlInstructionAccount]
     let args: [IdlField]
+    let defaultOptionalAccounts: Bool?
+    let docs: [String]?
 }
 
 public struct IdlState: Decodable {

--- a/Sources/Solita/RenderInstruction.swift
+++ b/Sources/Solita/RenderInstruction.swift
@@ -165,6 +165,18 @@ public struct \(self.argsTypename){
                 
                 let checkRequireds = requiredChecks.count > 0 ? "if \(requiredChecks) { fatalError(\"When providing \(key.name) \(requiredOptionals.map{ "accounts.\($0.name)"}.joined(separator: ", ")) need(s) to be provided as well.\") }" : ""
                 
+                let elseIfDefaultOptionalAccounts = ix.defaultOptionalAccounts == true ?
+"""
+ else {
+        keys.append(
+            AccountMeta(
+                publicKey: programId,
+                isSigner: false,
+                isWritable: false
+            )
+        )
+    }
+""" : ""
                 return
 """
     if accounts.\(key.name) != nil {
@@ -176,7 +188,7 @@ public struct \(self.argsTypename){
                 isWritable: \(key.isMut)
             )
         )
-    }
+    } \(elseIfDefaultOptionalAccounts)
 """
             }
             .joined(separator: "\n" ) + "\n"

--- a/Tests/SolitaTests/Data/TestDataProvider.swift
+++ b/Tests/SolitaTests/Data/TestDataProvider.swift
@@ -16,7 +16,7 @@ struct TestDataProvider {
     static let featDataEnum = stubbedResponse("feat-data-enum")
 
     static let discriminatorInstruction = InstructionDiscriminator(
-        ix: IdlInstruction(name: "createAuctionHouse", accounts: [], args: []),
+        ix: IdlInstruction(name: "createAuctionHouse", accounts: [], args: [], defaultOptionalAccounts: nil, docs: nil),
         fieldName: "createAuctionHouse",
         typeMapper: TypeMapper()
     )

--- a/Tests/SolitaTests/RenderInstructionTests.swift
+++ b/Tests/SolitaTests/RenderInstructionTests.swift
@@ -49,19 +49,19 @@ final class RenderInstructionTests: XCTestCase {
     func testIxEmptyArgs() {
         let ix = IdlInstruction(name: "empyArgs", accounts: [
             IdlInstructionAccount(name: "authority", isMut: false, isSigner: true, desc: nil, optional: nil)
-        ], args: [])
+        ], args: [], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
     func testIxEmptyArgEmptyAccounts() {
-        let ix = IdlInstruction(name: "empyArgs", accounts: [], args: [])
+        let ix = IdlInstruction(name: "empyArgs", accounts: [], args: [], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
     func testIxOneArg() {
         let ix = IdlInstruction(name: "oneArg", accounts: [
             IdlInstructionAccount(name: "authority", isMut: false, isSigner: true, desc: nil, optional: nil)
-        ], args: [.init(name: "amount", type: .beetTypeMapKey(.numbersTypeMapKey(.u64)), attrs: nil)])
+        ], args: [.init(name: "amount", type: .beetTypeMapKey(.numbersTypeMapKey(.u64)), attrs: nil)], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
@@ -71,7 +71,7 @@ final class RenderInstructionTests: XCTestCase {
         ], args: [
             .init(name: "amount", type: .beetTypeMapKey(.numbersTypeMapKey(.u64)), attrs: nil),
             .init(name: "authority", type: .publicKey(.keysTypeMapKey(.publicKey)), attrs: nil),
-        ])
+        ], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
@@ -82,7 +82,7 @@ final class RenderInstructionTests: XCTestCase {
         ], args: [
             .init(name: "amount", type: .beetTypeMapKey(.numbersTypeMapKey(.u64)), attrs: nil),
             .init(name: "authority", type: .publicKey(.keysTypeMapKey(.publicKey)), attrs: nil),
-        ])
+        ], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
@@ -91,7 +91,7 @@ final class RenderInstructionTests: XCTestCase {
             IdlInstructionAccount(name: "authority", isMut: false, isSigner: true, desc: nil, optional: nil),
             IdlInstructionAccount(name: "useAuthorityRecord", isMut: true, isSigner: false, desc: "Use Authority Record PDA If present the program Assumes a delegated use authority", optional: true),
             IdlInstructionAccount(name: "burner", isMut: false, isSigner: false, desc: "Program As Signer (Burner)", optional: true)
-        ], args: [])
+        ], args: [], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
@@ -99,7 +99,7 @@ final class RenderInstructionTests: XCTestCase {
         let ix = IdlInstruction(name: "choicy", accounts: [
             IdlInstructionAccount(name: "withoutDesc", isMut: false, isSigner: true, desc: nil, optional: nil),
             IdlInstructionAccount(name: "withDesc", isMut: true, isSigner: false, desc: "Use Authority Record PDA If present the program Assumes a delegated use authority", optional: true),
-        ], args: [])
+        ], args: [], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
@@ -107,7 +107,7 @@ final class RenderInstructionTests: XCTestCase {
         let ix = IdlInstruction(name: "empyArgsWithSystemProgram", accounts: [
             IdlInstructionAccount(name: "authority", isMut: false, isSigner: true, desc: nil, optional: nil),
             IdlInstructionAccount(name: "systemProgram", isMut: false, isSigner: false, desc: nil, optional: nil),
-        ], args: [])
+        ], args: [], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
@@ -116,7 +116,7 @@ final class RenderInstructionTests: XCTestCase {
             IdlInstructionAccount(name: "authority", isMut: false, isSigner: true, desc: nil, optional: nil),
             IdlInstructionAccount(name: "systemProgram", isMut: false, isSigner: false, desc: nil, optional: nil),
             IdlInstructionAccount(name: "programId", isMut: false, isSigner: false, desc: nil, optional: nil),
-        ], args: [])
+        ], args: [], defaultOptionalAccounts: nil, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
     
@@ -125,7 +125,25 @@ final class RenderInstructionTests: XCTestCase {
             IdlInstructionAccount(name: "authority", isMut: false, isSigner: true, desc: nil, optional: nil),
             IdlInstructionAccount(name: "systemProgram", isMut: false, isSigner: false, desc: nil, optional: nil),
             IdlInstructionAccount(name: "rent", isMut: false, isSigner: false, desc: nil, optional: true),
-        ], args: [])
+        ], args: [], defaultOptionalAccounts: nil, docs: nil)
+        checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
+    }
+    
+    func testIxEmptyArgsOneSystemProgramAccountOneOptionalRentAccountAndDefaultOptionalAccountsTrue() {
+        let ix = IdlInstruction(name: "empyArgsWithSystemProgram", accounts: [
+            IdlInstructionAccount(name: "authority", isMut: false, isSigner: true, desc: nil, optional: nil),
+            IdlInstructionAccount(name: "systemProgram", isMut: false, isSigner: false, desc: nil, optional: nil),
+            IdlInstructionAccount(name: "rent", isMut: false, isSigner: false, desc: nil, optional: true),
+        ], args: [], defaultOptionalAccounts: true, docs: nil)
+        checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
+    }
+    
+    func testIxEmptyArgsOneSystemProgramAccountOneOptionalRentAccountAndDefaultOptionalAccountsFalse() {
+        let ix = IdlInstruction(name: "empyArgsWithSystemProgram", accounts: [
+            IdlInstructionAccount(name: "authority", isMut: false, isSigner: true, desc: nil, optional: nil),
+            IdlInstructionAccount(name: "systemProgram", isMut: false, isSigner: false, desc: nil, optional: nil),
+            IdlInstructionAccount(name: "rent", isMut: false, isSigner: false, desc: nil, optional: true),
+        ], args: [], defaultOptionalAccounts: false, docs: nil)
         checkRenderedIx(ix: ix, imports: [.BEET_PACKAGE, .SOLANA_WEB3_PACKAGE])
     }
 }

--- a/Tests/SolitaTests/Resources/mpl_token_metadata.json
+++ b/Tests/SolitaTests/Resources/mpl_token_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0-beta.2",
+  "version": "1.3.1",
   "name": "mpl_token_metadata",
   "instructions": [
     {
@@ -721,8 +721,7 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info",
-          "optional": true
+          "desc": "Rent info"
         }
       ],
       "args": [
@@ -869,8 +868,7 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info",
-          "optional": true
+          "desc": "Rent info"
         }
       ],
       "args": [
@@ -974,8 +972,7 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info",
-          "optional": true
+          "desc": "Rent info"
         }
       ],
       "args": [
@@ -1046,8 +1043,7 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info",
-          "optional": true
+          "desc": "Rent info"
         }
       ],
       "args": [
@@ -1261,8 +1257,7 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info",
-          "optional": true
+          "desc": "Rent info"
         }
       ],
       "args": [
@@ -1333,8 +1328,7 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info",
-          "optional": true
+          "desc": "Rent info"
         }
       ],
       "args": [],
@@ -1439,8 +1433,7 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info",
-          "optional": true
+          "desc": "Rent info"
         }
       ],
       "args": [],
@@ -1461,7 +1454,7 @@
         {
           "name": "delegateAuthority",
           "isMut": true,
-          "isSigner": false,
+          "isSigner": true,
           "desc": "Delegated Collection Authority"
         },
         {
@@ -1911,8 +1904,7 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info",
-          "optional": true
+          "desc": "Rent info"
         }
       ],
       "args": [
@@ -2004,1500 +1996,31 @@
         "type": "u8",
         "value": 35
       }
-    },
-    {
-      "name": "BubblegumSetCollectionSize",
-      "accounts": [
-        {
-          "name": "collectionMetadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Collection Metadata account"
-        },
-        {
-          "name": "collectionAuthority",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Collection Update authority"
-        },
-        {
-          "name": "collectionMint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint of the Collection"
-        },
-        {
-          "name": "bubblegumSigner",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Signing PDA of Bubblegum program"
-        },
-        {
-          "name": "collectionAuthorityRecord",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Collection Authority Record PDA",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "setCollectionSizeArgs",
-          "type": {
-            "defined": "SetCollectionSizeArgs"
-          }
-        }
-      ],
-      "discriminant": {
-        "type": "u8",
-        "value": 36
-      }
-    },
-    {
-      "name": "BurnEditionNft",
-      "accounts": [
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata (pda of ['metadata', program id, mint id])"
-        },
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "NFT owner"
-        },
-        {
-          "name": "printEditionMint",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Mint of the print edition NFT"
-        },
-        {
-          "name": "masterEditionMint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint of the original/master NFT"
-        },
-        {
-          "name": "printEditionTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account the print edition NFT is in"
-        },
-        {
-          "name": "masterEditionTokenAccount",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token account the Master Edition NFT is in"
-        },
-        {
-          "name": "masterEditionAccount",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "MasterEdition2 of the original NFT"
-        },
-        {
-          "name": "printEditionAccount",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Print Edition account of the NFT"
-        },
-        {
-          "name": "editionMarkerAccount",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Edition Marker PDA of the NFT"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token Program"
-        }
-      ],
-      "args": [],
-      "discriminant": {
-        "type": "u8",
-        "value": 37
-      }
-    },
-    {
-      "name": "CreateEscrowAccount",
-      "accounts": [
-        {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Escrow account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account"
-        },
-        {
-          "name": "tokenAccount",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token account of the token"
-        },
-        {
-          "name": "edition",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Edition account"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Wallet paying for the transaction and new account"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instructions sysvar account"
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Authority/creator of the escrow account",
-          "optional": true
-        }
-      ],
-      "args": [],
-      "discriminant": {
-        "type": "u8",
-        "value": 38
-      }
-    },
-    {
-      "name": "CloseEscrowAccount",
-      "accounts": [
-        {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Escrow account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account"
-        },
-        {
-          "name": "tokenAccount",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token account"
-        },
-        {
-          "name": "edition",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Edition account"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Wallet paying for the transaction and new account"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instructions sysvar account"
-        }
-      ],
-      "args": [],
-      "discriminant": {
-        "type": "u8",
-        "value": 39
-      }
-    },
-    {
-      "name": "TransferOutOfEscrow",
-      "accounts": [
-        {
-          "name": "escrow",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Escrow account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Wallet paying for the transaction and new account"
-        },
-        {
-          "name": "attributeMint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account for the new attribute"
-        },
-        {
-          "name": "attributeSrc",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account source for the new attribute"
-        },
-        {
-          "name": "attributeDst",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account, owned by TM, destination for the new attribute"
-        },
-        {
-          "name": "escrowMint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account that the escrow is attached"
-        },
-        {
-          "name": "escrowAccount",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token account that holds the token the escrow is attached to"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "ataProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Associated Token program"
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instructions sysvar account"
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Authority/creator of the escrow account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "transferOutOfEscrowArgs",
-          "type": {
-            "defined": "TransferOutOfEscrowArgs"
-          }
-        }
-      ],
-      "discriminant": {
-        "type": "u8",
-        "value": 40
-      }
-    },
-    {
-      "name": "Burn",
-      "accounts": [
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata (pda of ['metadata', program id, mint id])"
-        },
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Asset owner"
-        },
-        {
-          "name": "mint",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Mint of token asset"
-        },
-        {
-          "name": "tokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account to close"
-        },
-        {
-          "name": "masterEditionAccount",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "MasterEdition of the asset"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token Program"
-        },
-        {
-          "name": "collectionMetadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata of the Collection",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "burnArgs",
-          "type": {
-            "defined": "BurnArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 41
-      }
-    },
-    {
-      "name": "Create",
-      "accounts": [
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Unallocated metadata account with address as pda of ['metadata', program id, mint id]"
-        },
-        {
-          "name": "masterEdition",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Unallocated edition account with address as pda of ['metadata', program id, mint, 'edition']",
-          "optional": true
-        },
-        {
-          "name": "mint",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Mint of token asset"
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Mint authority"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "updateAuthority",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Update authority for the metadata account"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instructions sysvar account"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token program"
-        }
-      ],
-      "args": [
-        {
-          "name": "createArgs",
-          "type": {
-            "defined": "CreateArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 42
-      }
-    },
-    {
-      "name": "Mint",
-      "accounts": [
-        {
-          "name": "token",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token or Associated Token account"
-        },
-        {
-          "name": "tokenOwner",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Owner of the token account",
-          "optional": true
-        },
-        {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Metadata account (pda of ['metadata', program id, mint id])"
-        },
-        {
-          "name": "masterEdition",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Master Edition account",
-          "optional": true
-        },
-        {
-          "name": "tokenRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token record account",
-          "optional": true
-        },
-        {
-          "name": "mint",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Mint of token asset"
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "(Mint or Update) authority"
-        },
-        {
-          "name": "delegateRecord",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Metadata delegate record",
-          "optional": true
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instructions sysvar account"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token program"
-        },
-        {
-          "name": "splAtaProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Associated Token Account program"
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "mintArgs",
-          "type": {
-            "defined": "MintArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 43
-      }
-    },
-    {
-      "name": "Delegate",
-      "accounts": [
-        {
-          "name": "delegateRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Delegate record account",
-          "optional": true
-        },
-        {
-          "name": "delegate",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Owner of the delegated account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "masterEdition",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Master Edition account",
-          "optional": true
-        },
-        {
-          "name": "tokenRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token record account",
-          "optional": true
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint of metadata"
-        },
-        {
-          "name": "token",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account of mint",
-          "optional": true
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Update authority or token owner"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System Program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instructions sysvar account"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "delegateArgs",
-          "type": {
-            "defined": "DelegateArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 44
-      }
-    },
-    {
-      "name": "Revoke",
-      "accounts": [
-        {
-          "name": "delegateRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Delegate record account",
-          "optional": true
-        },
-        {
-          "name": "delegate",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Owner of the delegated account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "masterEdition",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Master Edition account",
-          "optional": true
-        },
-        {
-          "name": "tokenRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token record account",
-          "optional": true
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint of metadata"
-        },
-        {
-          "name": "token",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account of mint",
-          "optional": true
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Update authority or token owner"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System Program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instructions sysvar account"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "revokeArgs",
-          "type": {
-            "defined": "RevokeArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 45
-      }
-    },
-    {
-      "name": "Lock",
-      "accounts": [
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Delegate account"
-        },
-        {
-          "name": "tokenOwner",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token owner account",
-          "optional": true
-        },
-        {
-          "name": "token",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account"
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "edition",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Edition account",
-          "optional": true
-        },
-        {
-          "name": "tokenRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token record account",
-          "optional": true
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "lockArgs",
-          "type": {
-            "defined": "LockArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 46
-      }
-    },
-    {
-      "name": "Unlock",
-      "accounts": [
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Delegate account"
-        },
-        {
-          "name": "tokenOwner",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token owner account",
-          "optional": true
-        },
-        {
-          "name": "token",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account"
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "edition",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Edition account",
-          "optional": true
-        },
-        {
-          "name": "tokenRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token record account",
-          "optional": true
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "unlockArgs",
-          "type": {
-            "defined": "UnlockArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 47
-      }
-    },
-    {
-      "name": "Migrate",
-      "accounts": [
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "edition",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Edition account"
-        },
-        {
-          "name": "token",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account"
-        },
-        {
-          "name": "tokenOwner",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token account owner"
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Update authority"
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Update authority"
-        },
-        {
-          "name": "collectionMetadata",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Collection metadata account"
-        },
-        {
-          "name": "delegateRecord",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Delegate record account"
-        },
-        {
-          "name": "tokenRecord",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token record account"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instruction sysvar account"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Program"
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "migrateArgs",
-          "type": {
-            "defined": "MigrateArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 48
-      }
-    },
-    {
-      "name": "Transfer",
-      "accounts": [
-        {
-          "name": "token",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account"
-        },
-        {
-          "name": "tokenOwner",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token account owner"
-        },
-        {
-          "name": "destination",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Destination token account"
-        },
-        {
-          "name": "destinationOwner",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Destination token account owner"
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint of token asset"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata (pda of ['metadata', program id, mint id])"
-        },
-        {
-          "name": "edition",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Edition of token asset",
-          "optional": true
-        },
-        {
-          "name": "ownerTokenRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token record account",
-          "optional": true
-        },
-        {
-          "name": "destinationTokenRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token record account",
-          "optional": true
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Transfer authority (token or delegate owner)"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System Program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Instructions sysvar account"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token Program"
-        },
-        {
-          "name": "splAtaProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Associated Token Account program"
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "transferArgs",
-          "type": {
-            "defined": "TransferArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 49
-      }
-    },
-    {
-      "name": "Update",
-      "accounts": [
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Update authority or delegate"
-        },
-        {
-          "name": "delegateRecord",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Delegate record PDA",
-          "optional": true
-        },
-        {
-          "name": "token",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token account",
-          "optional": true
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "edition",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Edition account",
-          "optional": true
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "updateArgs",
-          "type": {
-            "defined": "UpdateArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 50
-      }
-    },
-    {
-      "name": "Use",
-      "accounts": [
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Token owner or delegate"
-        },
-        {
-          "name": "delegateRecord",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Delegate record PDA",
-          "optional": true
-        },
-        {
-          "name": "token",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Token account",
-          "optional": true
-        },
-        {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Mint account"
-        },
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "edition",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Edition account",
-          "optional": true
-        },
-        {
-          "name": "payer",
-          "isMut": false,
-          "isSigner": true,
-          "desc": "Payer"
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "sysvarInstructions",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "System program"
-        },
-        {
-          "name": "splTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "SPL Token Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "useArgs",
-          "type": {
-            "defined": "UseArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 51
-      }
-    },
-    {
-      "name": "Verify",
-      "accounts": [
-        {
-          "name": "metadata",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Metadata account"
-        },
-        {
-          "name": "collectionAuthority",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "Collection Update authority"
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "desc": "payer"
-        },
-        {
-          "name": "authorizationRules",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules account",
-          "optional": true
-        },
-        {
-          "name": "authorizationRulesProgram",
-          "isMut": false,
-          "isSigner": false,
-          "desc": "Token Authorization Rules Program",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "verifyArgs",
-          "type": {
-            "defined": "VerifyArgs"
-          }
-        }
-      ],
-      "defaultOptionalAccounts": true,
-      "discriminant": {
-        "type": "u8",
-        "value": 52
-      }
     }
   ],
   "accounts": [
+    {
+      "name": "UseAuthorityRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "allowedUses",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
     {
       "name": "CollectionAuthorityRecord",
       "type": {
@@ -3512,171 +2035,6 @@
           {
             "name": "bump",
             "type": "u8"
-          },
-          {
-            "name": "updateAuthority",
-            "type": {
-              "option": "publicKey"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "MetadataDelegateRecord",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "Key"
-            }
-          },
-          {
-            "name": "bump",
-            "type": "u8"
-          },
-          {
-            "name": "mint",
-            "type": "publicKey"
-          },
-          {
-            "name": "delegate",
-            "type": "publicKey"
-          },
-          {
-            "name": "updateAuthority",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Edition",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "Key"
-            }
-          },
-          {
-            "name": "parent",
-            "type": "publicKey"
-          },
-          {
-            "name": "edition",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "EditionMarker",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "Key"
-            }
-          },
-          {
-            "name": "ledger",
-            "type": {
-              "array": [
-                "u8",
-                31
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenOwnedEscrow",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "Key"
-            }
-          },
-          {
-            "name": "baseToken",
-            "type": "publicKey"
-          },
-          {
-            "name": "authority",
-            "type": {
-              "defined": "EscrowAuthority"
-            }
-          },
-          {
-            "name": "bump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "MasterEditionV2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "Key"
-            }
-          },
-          {
-            "name": "supply",
-            "type": "u64"
-          },
-          {
-            "name": "maxSupply",
-            "type": {
-              "option": "u64"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "MasterEditionV1",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "Key"
-            }
-          },
-          {
-            "name": "supply",
-            "type": "u64"
-          },
-          {
-            "name": "maxSupply",
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
-            "name": "printingMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "oneTimePrintingAuthorizationMint",
-            "type": "publicKey"
           }
         ]
       }
@@ -3751,20 +2109,12 @@
                 "defined": "CollectionDetails"
               }
             }
-          },
-          {
-            "name": "programmableConfig",
-            "type": {
-              "option": {
-                "defined": "ProgrammableConfig"
-              }
-            }
           }
         ]
       }
     },
     {
-      "name": "TokenRecord",
+      "name": "MasterEditionV2",
       "type": {
         "kind": "struct",
         "fields": [
@@ -3775,34 +2125,68 @@
             }
           },
           {
-            "name": "bump",
-            "type": "u8"
+            "name": "supply",
+            "type": "u64"
           },
           {
-            "name": "state",
+            "name": "maxSupply",
             "type": {
-              "defined": "TokenState"
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MasterEditionV1",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
             }
           },
           {
-            "name": "ruleSetRevision",
+            "name": "supply",
+            "type": "u64"
+          },
+          {
+            "name": "maxSupply",
             "type": {
               "option": "u64"
             }
           },
           {
-            "name": "delegate",
+            "name": "printingMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "oneTimePrintingAuthorizationMint",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Edition",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
             "type": {
-              "option": "publicKey"
+              "defined": "Key"
             }
           },
           {
-            "name": "delegateRole",
-            "type": {
-              "option": {
-                "defined": "TokenDelegateRole"
-              }
-            }
+            "name": "parent",
+            "type": "publicKey"
+          },
+          {
+            "name": "edition",
+            "type": "u64"
           }
         ]
       }
@@ -3880,7 +2264,7 @@
       }
     },
     {
-      "name": "UseAuthorityRecord",
+      "name": "EditionMarker",
       "type": {
         "kind": "struct",
         "fields": [
@@ -3891,94 +2275,16 @@
             }
           },
           {
-            "name": "allowedUses",
-            "type": "u64"
-          },
-          {
-            "name": "bump",
-            "type": "u8"
+            "name": "ledger",
+            "type": {
+              "array": ["u8", 31]
+            }
           }
         ]
       }
     }
   ],
   "types": [
-    {
-      "name": "SetCollectionSizeArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "size",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CreateMetadataAccountArgsV2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "data",
-            "type": {
-              "defined": "DataV2"
-            }
-          },
-          {
-            "name": "isMutable",
-            "type": "bool"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CreateMetadataAccountArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "data",
-            "type": {
-              "defined": "Data"
-            }
-          },
-          {
-            "name": "isMutable",
-            "type": "bool"
-          }
-        ]
-      }
-    },
-    {
-      "name": "UpdateMetadataAccountArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "data",
-            "type": {
-              "option": {
-                "defined": "Data"
-              }
-            }
-          },
-          {
-            "name": "updateAuthority",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "primarySaleHappened",
-            "type": {
-              "option": "bool"
-            }
-          }
-        ]
-      }
-    },
     {
       "name": "MintPrintingTokensViaTokenArgs",
       "type": {
@@ -4022,64 +2328,28 @@
       }
     },
     {
-      "name": "CreateMasterEditionArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "maxSupply",
-            "type": {
-              "option": "u64"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "MintNewEditionFromMasterEditionViaTokenArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "edition",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TransferOutOfEscrowArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CreateMetadataAccountArgsV3",
+      "name": "UpdateMetadataAccountArgs",
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "data",
             "type": {
-              "defined": "DataV2"
+              "option": {
+                "defined": "Data"
+              }
             }
           },
           {
-            "name": "isMutable",
-            "type": "bool"
+            "name": "updateAuthority",
+            "type": {
+              "option": "publicKey"
+            }
           },
           {
-            "name": "collectionDetails",
+            "name": "primarySaleHappened",
             "type": {
-              "option": {
-                "defined": "CollectionDetails"
-              }
+              "option": "bool"
             }
           }
         ]
@@ -4120,6 +2390,94 @@
       }
     },
     {
+      "name": "CreateMetadataAccountArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "defined": "Data"
+            }
+          },
+          {
+            "name": "isMutable",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateMetadataAccountArgsV2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "defined": "DataV2"
+            }
+          },
+          {
+            "name": "isMutable",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateMetadataAccountArgsV3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "defined": "DataV2"
+            }
+          },
+          {
+            "name": "isMutable",
+            "type": "bool"
+          },
+          {
+            "name": "collectionDetails",
+            "type": {
+              "option": {
+                "defined": "CollectionDetails"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateMasterEditionArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "maxSupply",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintNewEditionFromMasterEditionViaTokenArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "edition",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "ApproveUseAuthorityArgs",
       "type": {
         "kind": "struct",
@@ -4144,129 +2502,13 @@
       }
     },
     {
-      "name": "AuthorizationData",
+      "name": "SetCollectionSizeArgs",
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "payload",
-            "type": {
-              "defined": "Payload"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "AssetData",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "name",
-            "type": "string"
-          },
-          {
-            "name": "symbol",
-            "type": "string"
-          },
-          {
-            "name": "uri",
-            "type": "string"
-          },
-          {
-            "name": "sellerFeeBasisPoints",
-            "type": "u16"
-          },
-          {
-            "name": "creators",
-            "type": {
-              "option": {
-                "vec": {
-                  "defined": "Creator"
-                }
-              }
-            }
-          },
-          {
-            "name": "primarySaleHappened",
-            "type": "bool"
-          },
-          {
-            "name": "isMutable",
-            "type": "bool"
-          },
-          {
-            "name": "tokenStandard",
-            "type": {
-              "defined": "TokenStandard"
-            }
-          },
-          {
-            "name": "collection",
-            "type": {
-              "option": {
-                "defined": "Collection"
-              }
-            }
-          },
-          {
-            "name": "uses",
-            "type": {
-              "option": {
-                "defined": "Uses"
-              }
-            }
-          },
-          {
-            "name": "collectionDetails",
-            "type": {
-              "option": {
-                "defined": "CollectionDetails"
-              }
-            }
-          },
-          {
-            "name": "ruleSet",
-            "type": {
-              "option": "publicKey"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Collection",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "verified",
-            "type": "bool"
-          },
-          {
-            "name": "key",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Creator",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "address",
-            "type": "publicKey"
-          },
-          {
-            "name": "verified",
-            "type": "bool"
-          },
-          {
-            "name": "share",
-            "type": "u8"
+            "name": "size",
+            "type": "u64"
           }
         ]
       }
@@ -4356,6 +2598,64 @@
       }
     },
     {
+      "name": "Uses",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "useMethod",
+            "type": {
+              "defined": "UseMethod"
+            }
+          },
+          {
+            "name": "remaining",
+            "type": "u64"
+          },
+          {
+            "name": "total",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Collection",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "verified",
+            "type": "bool"
+          },
+          {
+            "name": "key",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Creator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "address",
+            "type": "publicKey"
+          },
+          {
+            "name": "verified",
+            "type": "bool"
+          },
+          {
+            "name": "share",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
       "name": "Reservation",
       "type": {
         "kind": "struct",
@@ -4396,644 +2696,6 @@
       }
     },
     {
-      "name": "SeedsVec",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "seeds",
-            "type": {
-              "vec": "bytes"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "LeafInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "leaf",
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "proof",
-            "type": {
-              "vec": {
-                "array": [
-                  "u8",
-                  32
-                ]
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Payload",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "map",
-            "type": {
-              "hashMap": [
-                {
-                  "defined": "PayloadKey"
-                },
-                {
-                  "defined": "PayloadType"
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Uses",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "useMethod",
-            "type": {
-              "defined": "UseMethod"
-            }
-          },
-          {
-            "name": "remaining",
-            "type": "u64"
-          },
-          {
-            "name": "total",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "BurnArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "VerifyArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "DelegateArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "CollectionV1",
-            "fields": [
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "name": "SaleV1",
-            "fields": [
-              {
-                "name": "amount",
-                "type": "u64"
-              },
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "name": "TransferV1",
-            "fields": [
-              {
-                "name": "amount",
-                "type": "u64"
-              },
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "name": "UpdateV1",
-            "fields": [
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "name": "UtilityV1",
-            "fields": [
-              {
-                "name": "amount",
-                "type": "u64"
-              },
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "name": "StakingV1",
-            "fields": [
-              {
-                "name": "amount",
-                "type": "u64"
-              },
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "name": "StandardV1",
-            "fields": [
-              {
-                "name": "amount",
-                "type": "u64"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "RevokeArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "CollectionV1"
-          },
-          {
-            "name": "SaleV1"
-          },
-          {
-            "name": "TransferV1"
-          },
-          {
-            "name": "UpdateV1"
-          },
-          {
-            "name": "UtilityV1"
-          },
-          {
-            "name": "StakingV1"
-          },
-          {
-            "name": "StandardV1"
-          }
-        ]
-      }
-    },
-    {
-      "name": "MetadataDelegateRole",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Authority"
-          },
-          {
-            "name": "Collection"
-          },
-          {
-            "name": "Use"
-          },
-          {
-            "name": "Update"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CreateArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "asset_data",
-                "type": {
-                  "defined": "AssetData"
-                }
-              },
-              {
-                "name": "decimals",
-                "type": {
-                  "option": "u8"
-                }
-              },
-              {
-                "name": "print_supply",
-                "type": {
-                  "option": {
-                    "defined": "PrintSupply"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "MintArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "amount",
-                "type": "u64"
-              },
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "TransferArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "amount",
-                "type": "u64"
-              },
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "UpdateArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "new_update_authority",
-                "type": {
-                  "option": "publicKey"
-                }
-              },
-              {
-                "name": "data",
-                "type": {
-                  "option": {
-                    "defined": "Data"
-                  }
-                }
-              },
-              {
-                "name": "primary_sale_happened",
-                "type": {
-                  "option": "bool"
-                }
-              },
-              {
-                "name": "is_mutable",
-                "type": {
-                  "option": "bool"
-                }
-              },
-              {
-                "name": "collection",
-                "type": {
-                  "defined": "CollectionToggle"
-                }
-              },
-              {
-                "name": "collection_details",
-                "type": {
-                  "defined": "CollectionDetailsToggle"
-                }
-              },
-              {
-                "name": "uses",
-                "type": {
-                  "defined": "UsesToggle"
-                }
-              },
-              {
-                "name": "rule_set",
-                "type": {
-                  "defined": "RuleSetToggle"
-                }
-              },
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "CollectionToggle",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "None"
-          },
-          {
-            "name": "Clear"
-          },
-          {
-            "name": "Set",
-            "fields": [
-              {
-                "defined": "Collection"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "UsesToggle",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "None"
-          },
-          {
-            "name": "Clear"
-          },
-          {
-            "name": "Set",
-            "fields": [
-              {
-                "defined": "Uses"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "CollectionDetailsToggle",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "None"
-          },
-          {
-            "name": "Clear"
-          },
-          {
-            "name": "Set",
-            "fields": [
-              {
-                "defined": "CollectionDetails"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "RuleSetToggle",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "None"
-          },
-          {
-            "name": "Clear"
-          },
-          {
-            "name": "Set",
-            "fields": [
-              "publicKey"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "MigrateArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "migration_type",
-                "type": {
-                  "defined": "MigrationType"
-                }
-              },
-              {
-                "name": "rule_set",
-                "type": {
-                  "option": "publicKey"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "UnlockArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "UseArgs",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "authorization_data",
-                "type": {
-                  "option": {
-                    "defined": "AuthorizationData"
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenStandard",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "NonFungible"
-          },
-          {
-            "name": "FungibleAsset"
-          },
-          {
-            "name": "Fungible"
-          },
-          {
-            "name": "NonFungibleEdition"
-          },
-          {
-            "name": "ProgrammableNonFungible"
-          }
-        ]
-      }
-    },
-    {
       "name": "Key",
       "type": {
         "kind": "enum",
@@ -5067,15 +2729,23 @@
           },
           {
             "name": "CollectionAuthorityRecord"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UseMethod",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Burn"
           },
           {
-            "name": "TokenOwnedEscrow"
+            "name": "Multiple"
           },
           {
-            "name": "TokenRecord"
-          },
-          {
-            "name": "MetadataDelegate"
+            "name": "Single"
           }
         ]
       }
@@ -5098,207 +2768,21 @@
       }
     },
     {
-      "name": "EscrowAuthority",
+      "name": "TokenStandard",
       "type": {
         "kind": "enum",
         "variants": [
           {
-            "name": "TokenOwner"
+            "name": "NonFungible"
           },
           {
-            "name": "Creator",
-            "fields": [
-              "publicKey"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "PrintSupply",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Zero"
+            "name": "FungibleAsset"
           },
           {
-            "name": "Limited",
-            "fields": [
-              "u64"
-            ]
+            "name": "Fungible"
           },
           {
-            "name": "Unlimited"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ProgrammableConfig",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V1",
-            "fields": [
-              {
-                "name": "rule_set",
-                "type": {
-                  "option": "publicKey"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "MigrationType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "CollectionV1"
-          },
-          {
-            "name": "ProgrammableV1"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenState",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Unlocked"
-          },
-          {
-            "name": "Locked"
-          },
-          {
-            "name": "Listed"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenDelegateRole",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Sale"
-          },
-          {
-            "name": "Transfer"
-          },
-          {
-            "name": "Utility"
-          },
-          {
-            "name": "Staking"
-          },
-          {
-            "name": "Standard"
-          },
-          {
-            "name": "Migration"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AuthorityType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "None"
-          },
-          {
-            "name": "Metadata"
-          },
-          {
-            "name": "Delegate"
-          },
-          {
-            "name": "Holder"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PayloadType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Pubkey",
-            "fields": [
-              "publicKey"
-            ]
-          },
-          {
-            "name": "Seeds",
-            "fields": [
-              {
-                "defined": "SeedsVec"
-              }
-            ]
-          },
-          {
-            "name": "MerkleProof",
-            "fields": [
-              {
-                "defined": "LeafInfo"
-              }
-            ]
-          },
-          {
-            "name": "Number",
-            "fields": [
-              "u64"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "PayloadKey",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Target"
-          },
-          {
-            "name": "Holder"
-          },
-          {
-            "name": "Authority"
-          },
-          {
-            "name": "Amount"
-          }
-        ]
-      }
-    },
-    {
-      "name": "UseMethod",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Burn"
-          },
-          {
-            "name": "Multiple"
-          },
-          {
-            "name": "Single"
+            "name": "NonFungibleEdition"
           }
         ]
       }
@@ -5678,7 +3162,7 @@
     {
       "code": 74,
       "name": "CollectionCannotBeVerifiedInThisInstruction",
-      "msg": "Collection cannot be verified in this instruction"
+      "msg": "Cannont Verify Collection in this Instruction"
     },
     {
       "code": 75,
@@ -5864,297 +3348,12 @@
       "code": 111,
       "name": "BorshDeserializationError",
       "msg": "Borsh Deserialization Error"
-    },
-    {
-      "code": 112,
-      "name": "CannotUpdateVerifiedCollection",
-      "msg": "Cannot update a verified collection in this command"
-    },
-    {
-      "code": 113,
-      "name": "CollectionMasterEditionAccountInvalid",
-      "msg": "Edition account doesnt match collection "
-    },
-    {
-      "code": 114,
-      "name": "AlreadyVerified",
-      "msg": "Item is already verified."
-    },
-    {
-      "code": 115,
-      "name": "AlreadyUnverified",
-      "msg": "Item is already unverified."
-    },
-    {
-      "code": 116,
-      "name": "NotAPrintEdition",
-      "msg": "This edition is not a Print Edition"
-    },
-    {
-      "code": 117,
-      "name": "InvalidMasterEdition",
-      "msg": "Invalid Master Edition"
-    },
-    {
-      "code": 118,
-      "name": "InvalidPrintEdition",
-      "msg": "Invalid Print Edition"
-    },
-    {
-      "code": 119,
-      "name": "InvalidEditionMarker",
-      "msg": "Invalid Edition Marker"
-    },
-    {
-      "code": 120,
-      "name": "ReservationListDeprecated",
-      "msg": "Reservation List is Deprecated"
-    },
-    {
-      "code": 121,
-      "name": "PrintEditionDoesNotMatchMasterEdition",
-      "msg": "Print Edition does not match Master Edition"
-    },
-    {
-      "code": 122,
-      "name": "EditionNumberGreaterThanMaxSupply",
-      "msg": "Edition Number greater than max supply"
-    },
-    {
-      "code": 123,
-      "name": "MustUnverify",
-      "msg": "Must unverify before migrating collections."
-    },
-    {
-      "code": 124,
-      "name": "InvalidEscrowBumpSeed",
-      "msg": "Invalid Escrow Account Bump Seed"
-    },
-    {
-      "code": 125,
-      "name": "MustBeEscrowAuthority",
-      "msg": "Must Escrow Authority"
-    },
-    {
-      "code": 126,
-      "name": "InvalidSystemProgram",
-      "msg": "Invalid System Program"
-    },
-    {
-      "code": 127,
-      "name": "MustBeNonFungible",
-      "msg": "Must be a Non Fungible Token"
-    },
-    {
-      "code": 128,
-      "name": "InsufficientTokens",
-      "msg": "Insufficient tokens for transfer"
-    },
-    {
-      "code": 129,
-      "name": "BorshSerializationError",
-      "msg": "Borsh Serialization Error"
-    },
-    {
-      "code": 130,
-      "name": "NoFreezeAuthoritySet",
-      "msg": "Cannot create NFT with no Freeze Authority."
-    },
-    {
-      "code": 131,
-      "name": "InvalidCollectionSizeChange",
-      "msg": "Invalid collection size change"
-    },
-    {
-      "code": 132,
-      "name": "InvalidBubblegumSigner",
-      "msg": "Invalid bubblegum signer"
-    },
-    {
-      "code": 133,
-      "name": "EscrowParentHasDelegate",
-      "msg": "Escrow parent cannot have a delegate"
-    },
-    {
-      "code": 134,
-      "name": "MintIsNotSigner",
-      "msg": "Mint needs to be signer to initialize the account"
-    },
-    {
-      "code": 135,
-      "name": "InvalidTokenStandard",
-      "msg": "Invalid token standard"
-    },
-    {
-      "code": 136,
-      "name": "InvalidMintForTokenStandard",
-      "msg": "Invalid mint account for specified token standard"
-    },
-    {
-      "code": 137,
-      "name": "InvalidAuthorizationRules",
-      "msg": "Invalid authorization rules account"
-    },
-    {
-      "code": 138,
-      "name": "MissingAuthorizationRules",
-      "msg": "Missing authorization rules account"
-    },
-    {
-      "code": 139,
-      "name": "MissingProgrammableConfig",
-      "msg": "Missing programmable configuration"
-    },
-    {
-      "code": 140,
-      "name": "InvalidProgrammableConfig",
-      "msg": "Invalid programmable configuration"
-    },
-    {
-      "code": 141,
-      "name": "DelegateAlreadyExists",
-      "msg": "Delegate already exists"
-    },
-    {
-      "code": 142,
-      "name": "DelegateNotFound",
-      "msg": "Delegate not found"
-    },
-    {
-      "code": 143,
-      "name": "MissingAccountInBuilder",
-      "msg": "Required account not set in instruction builder"
-    },
-    {
-      "code": 144,
-      "name": "MissingArgumentInBuilder",
-      "msg": "Required argument not set in instruction builder"
-    },
-    {
-      "code": 145,
-      "name": "FeatureNotSupported",
-      "msg": "Feature not supported currently"
-    },
-    {
-      "code": 146,
-      "name": "InvalidSystemWallet",
-      "msg": "Invalid system wallet"
-    },
-    {
-      "code": 147,
-      "name": "OnlySaleDelegateCanTransfer",
-      "msg": "Only the sale delegate can transfer while its set"
-    },
-    {
-      "code": 148,
-      "name": "MissingTokenAccount",
-      "msg": "Missing token account"
-    },
-    {
-      "code": 149,
-      "name": "MissingSplTokenProgram",
-      "msg": "Missing SPL token program"
-    },
-    {
-      "code": 150,
-      "name": "MissingAuthorizationRulesProgram",
-      "msg": "Missing authorization rules program"
-    },
-    {
-      "code": 151,
-      "name": "InvalidDelegateRoleForTransfer",
-      "msg": "Invalid delegate role for transfer"
-    },
-    {
-      "code": 152,
-      "name": "InvalidTransferAuthority",
-      "msg": "Invalid transfer authority"
-    },
-    {
-      "code": 153,
-      "name": "InstructionNotSupported",
-      "msg": "Instruction not supported for ProgrammableNonFungible assets"
-    },
-    {
-      "code": 154,
-      "name": "KeyMismatch",
-      "msg": "Public key does not match expected value"
-    },
-    {
-      "code": 155,
-      "name": "LockedToken",
-      "msg": "Token is locked"
-    },
-    {
-      "code": 156,
-      "name": "UnlockedToken",
-      "msg": "Token is unlocked"
-    },
-    {
-      "code": 157,
-      "name": "MissingDelegateRole",
-      "msg": "Missing delegate role"
-    },
-    {
-      "code": 158,
-      "name": "InvalidAuthorityType",
-      "msg": "Invalid authority type"
-    },
-    {
-      "code": 159,
-      "name": "MissingTokenRecord",
-      "msg": "Missing token record account"
-    },
-    {
-      "code": 160,
-      "name": "MintSupplyMustBeZero",
-      "msg": "Mint supply must be zero for programmable assets"
-    },
-    {
-      "code": 161,
-      "name": "DataIsEmptyOrZeroed",
-      "msg": "Data is empty or zeroed"
-    },
-    {
-      "code": 162,
-      "name": "MissingTokenOwnerAccount",
-      "msg": "Missing token owner"
-    },
-    {
-      "code": 163,
-      "name": "InvalidMasterEditionAccountLength",
-      "msg": "Master edition account has an invalid length"
-    },
-    {
-      "code": 164,
-      "name": "IncorrectTokenState",
-      "msg": "Incorrect token state"
-    },
-    {
-      "code": 165,
-      "name": "InvalidDelegateRole",
-      "msg": "Invalid delegate role"
-    },
-    {
-      "code": 166,
-      "name": "MissingPrintSupply",
-      "msg": "Print supply is required for non-fungibles"
-    },
-    {
-      "code": 167,
-      "name": "MissingMasterEditionAccount",
-      "msg": "Missing master edition account"
-    },
-    {
-      "code": 168,
-      "name": "AmountMustBeGreaterThanZero",
-      "msg": "Amount must be greater than zero"
     }
   ],
   "metadata": {
     "origin": "shank",
     "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-    "binaryVersion": "0.0.11",
-    "libVersion": "0.0.11"
+    "binaryVersion": "0.0.3",
+    "libVersion": "~0.0.2"
   }
 }

--- a/Tests/SolitaTests/Resources/mpl_token_metadata.json
+++ b/Tests/SolitaTests/Resources/mpl_token_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.1",
+  "version": "1.7.0-beta.2",
   "name": "mpl_token_metadata",
   "instructions": [
     {
@@ -721,7 +721,8 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info"
+          "desc": "Rent info",
+          "optional": true
         }
       ],
       "args": [
@@ -868,7 +869,8 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info"
+          "desc": "Rent info",
+          "optional": true
         }
       ],
       "args": [
@@ -972,7 +974,8 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info"
+          "desc": "Rent info",
+          "optional": true
         }
       ],
       "args": [
@@ -1043,7 +1046,8 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info"
+          "desc": "Rent info",
+          "optional": true
         }
       ],
       "args": [
@@ -1257,7 +1261,8 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info"
+          "desc": "Rent info",
+          "optional": true
         }
       ],
       "args": [
@@ -1328,7 +1333,8 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info"
+          "desc": "Rent info",
+          "optional": true
         }
       ],
       "args": [],
@@ -1433,7 +1439,8 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info"
+          "desc": "Rent info",
+          "optional": true
         }
       ],
       "args": [],
@@ -1454,7 +1461,7 @@
         {
           "name": "delegateAuthority",
           "isMut": true,
-          "isSigner": true,
+          "isSigner": false,
           "desc": "Delegated Collection Authority"
         },
         {
@@ -1904,7 +1911,8 @@
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "desc": "Rent info"
+          "desc": "Rent info",
+          "optional": true
         }
       ],
       "args": [
@@ -1996,31 +2004,1500 @@
         "type": "u8",
         "value": 35
       }
+    },
+    {
+      "name": "BubblegumSetCollectionSize",
+      "accounts": [
+        {
+          "name": "collectionMetadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Collection Metadata account"
+        },
+        {
+          "name": "collectionAuthority",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Collection Update authority"
+        },
+        {
+          "name": "collectionMint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint of the Collection"
+        },
+        {
+          "name": "bubblegumSigner",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Signing PDA of Bubblegum program"
+        },
+        {
+          "name": "collectionAuthorityRecord",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Collection Authority Record PDA",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "setCollectionSizeArgs",
+          "type": {
+            "defined": "SetCollectionSizeArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 36
+      }
+    },
+    {
+      "name": "BurnEditionNft",
+      "accounts": [
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata (pda of ['metadata', program id, mint id])"
+        },
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "NFT owner"
+        },
+        {
+          "name": "printEditionMint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Mint of the print edition NFT"
+        },
+        {
+          "name": "masterEditionMint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint of the original/master NFT"
+        },
+        {
+          "name": "printEditionTokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account the print edition NFT is in"
+        },
+        {
+          "name": "masterEditionTokenAccount",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token account the Master Edition NFT is in"
+        },
+        {
+          "name": "masterEditionAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "MasterEdition2 of the original NFT"
+        },
+        {
+          "name": "printEditionAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Print Edition account of the NFT"
+        },
+        {
+          "name": "editionMarkerAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Edition Marker PDA of the NFT"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token Program"
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 37
+      }
+    },
+    {
+      "name": "CreateEscrowAccount",
+      "accounts": [
+        {
+          "name": "escrow",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Escrow account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account"
+        },
+        {
+          "name": "tokenAccount",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token account of the token"
+        },
+        {
+          "name": "edition",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Edition account"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Wallet paying for the transaction and new account"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instructions sysvar account"
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority/creator of the escrow account",
+          "optional": true
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 38
+      }
+    },
+    {
+      "name": "CloseEscrowAccount",
+      "accounts": [
+        {
+          "name": "escrow",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Escrow account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account"
+        },
+        {
+          "name": "tokenAccount",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token account"
+        },
+        {
+          "name": "edition",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Edition account"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Wallet paying for the transaction and new account"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instructions sysvar account"
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 39
+      }
+    },
+    {
+      "name": "TransferOutOfEscrow",
+      "accounts": [
+        {
+          "name": "escrow",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Escrow account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Wallet paying for the transaction and new account"
+        },
+        {
+          "name": "attributeMint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account for the new attribute"
+        },
+        {
+          "name": "attributeSrc",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account source for the new attribute"
+        },
+        {
+          "name": "attributeDst",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account, owned by TM, destination for the new attribute"
+        },
+        {
+          "name": "escrowMint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account that the escrow is attached"
+        },
+        {
+          "name": "escrowAccount",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token account that holds the token the escrow is attached to"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "ataProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Associated Token program"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instructions sysvar account"
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority/creator of the escrow account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "transferOutOfEscrowArgs",
+          "type": {
+            "defined": "TransferOutOfEscrowArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 40
+      }
+    },
+    {
+      "name": "Burn",
+      "accounts": [
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata (pda of ['metadata', program id, mint id])"
+        },
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Asset owner"
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Mint of token asset"
+        },
+        {
+          "name": "tokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account to close"
+        },
+        {
+          "name": "masterEditionAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "MasterEdition of the asset"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token Program"
+        },
+        {
+          "name": "collectionMetadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata of the Collection",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "burnArgs",
+          "type": {
+            "defined": "BurnArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 41
+      }
+    },
+    {
+      "name": "Create",
+      "accounts": [
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Unallocated metadata account with address as pda of ['metadata', program id, mint id]"
+        },
+        {
+          "name": "masterEdition",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Unallocated edition account with address as pda of ['metadata', program id, mint, 'edition']",
+          "optional": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Mint of token asset"
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Mint authority"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "updateAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Update authority for the metadata account"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instructions sysvar account"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token program"
+        }
+      ],
+      "args": [
+        {
+          "name": "createArgs",
+          "type": {
+            "defined": "CreateArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 42
+      }
+    },
+    {
+      "name": "Mint",
+      "accounts": [
+        {
+          "name": "token",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token or Associated Token account"
+        },
+        {
+          "name": "tokenOwner",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Owner of the token account",
+          "optional": true
+        },
+        {
+          "name": "metadata",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Metadata account (pda of ['metadata', program id, mint id])"
+        },
+        {
+          "name": "masterEdition",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Master Edition account",
+          "optional": true
+        },
+        {
+          "name": "tokenRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token record account",
+          "optional": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Mint of token asset"
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "(Mint or Update) authority"
+        },
+        {
+          "name": "delegateRecord",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Metadata delegate record",
+          "optional": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instructions sysvar account"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token program"
+        },
+        {
+          "name": "splAtaProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Associated Token Account program"
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "mintArgs",
+          "type": {
+            "defined": "MintArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 43
+      }
+    },
+    {
+      "name": "Delegate",
+      "accounts": [
+        {
+          "name": "delegateRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Delegate record account",
+          "optional": true
+        },
+        {
+          "name": "delegate",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Owner of the delegated account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "masterEdition",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Master Edition account",
+          "optional": true
+        },
+        {
+          "name": "tokenRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token record account",
+          "optional": true
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint of metadata"
+        },
+        {
+          "name": "token",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account of mint",
+          "optional": true
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Update authority or token owner"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System Program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instructions sysvar account"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "delegateArgs",
+          "type": {
+            "defined": "DelegateArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 44
+      }
+    },
+    {
+      "name": "Revoke",
+      "accounts": [
+        {
+          "name": "delegateRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Delegate record account",
+          "optional": true
+        },
+        {
+          "name": "delegate",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Owner of the delegated account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "masterEdition",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Master Edition account",
+          "optional": true
+        },
+        {
+          "name": "tokenRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token record account",
+          "optional": true
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint of metadata"
+        },
+        {
+          "name": "token",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account of mint",
+          "optional": true
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Update authority or token owner"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System Program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instructions sysvar account"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "revokeArgs",
+          "type": {
+            "defined": "RevokeArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 45
+      }
+    },
+    {
+      "name": "Lock",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Delegate account"
+        },
+        {
+          "name": "tokenOwner",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token owner account",
+          "optional": true
+        },
+        {
+          "name": "token",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account"
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "edition",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Edition account",
+          "optional": true
+        },
+        {
+          "name": "tokenRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token record account",
+          "optional": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "lockArgs",
+          "type": {
+            "defined": "LockArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 46
+      }
+    },
+    {
+      "name": "Unlock",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Delegate account"
+        },
+        {
+          "name": "tokenOwner",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token owner account",
+          "optional": true
+        },
+        {
+          "name": "token",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account"
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "edition",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Edition account",
+          "optional": true
+        },
+        {
+          "name": "tokenRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token record account",
+          "optional": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "unlockArgs",
+          "type": {
+            "defined": "UnlockArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 47
+      }
+    },
+    {
+      "name": "Migrate",
+      "accounts": [
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "edition",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Edition account"
+        },
+        {
+          "name": "token",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account"
+        },
+        {
+          "name": "tokenOwner",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token account owner"
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Update authority"
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Update authority"
+        },
+        {
+          "name": "collectionMetadata",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Collection metadata account"
+        },
+        {
+          "name": "delegateRecord",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Delegate record account"
+        },
+        {
+          "name": "tokenRecord",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token record account"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instruction sysvar account"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Program"
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "migrateArgs",
+          "type": {
+            "defined": "MigrateArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 48
+      }
+    },
+    {
+      "name": "Transfer",
+      "accounts": [
+        {
+          "name": "token",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account"
+        },
+        {
+          "name": "tokenOwner",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token account owner"
+        },
+        {
+          "name": "destination",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Destination token account"
+        },
+        {
+          "name": "destinationOwner",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Destination token account owner"
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint of token asset"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata (pda of ['metadata', program id, mint id])"
+        },
+        {
+          "name": "edition",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Edition of token asset",
+          "optional": true
+        },
+        {
+          "name": "ownerTokenRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token record account",
+          "optional": true
+        },
+        {
+          "name": "destinationTokenRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token record account",
+          "optional": true
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Transfer authority (token or delegate owner)"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System Program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Instructions sysvar account"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token Program"
+        },
+        {
+          "name": "splAtaProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Associated Token Account program"
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "transferArgs",
+          "type": {
+            "defined": "TransferArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 49
+      }
+    },
+    {
+      "name": "Update",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Update authority or delegate"
+        },
+        {
+          "name": "delegateRecord",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Delegate record PDA",
+          "optional": true
+        },
+        {
+          "name": "token",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token account",
+          "optional": true
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "edition",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Edition account",
+          "optional": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "updateArgs",
+          "type": {
+            "defined": "UpdateArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 50
+      }
+    },
+    {
+      "name": "Use",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Token owner or delegate"
+        },
+        {
+          "name": "delegateRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Delegate record PDA",
+          "optional": true
+        },
+        {
+          "name": "token",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account",
+          "optional": true
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Mint account"
+        },
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "edition",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Edition account",
+          "optional": true
+        },
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "sysvarInstructions",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System program"
+        },
+        {
+          "name": "splTokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "SPL Token Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "useArgs",
+          "type": {
+            "defined": "UseArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 51
+      }
+    },
+    {
+      "name": "Verify",
+      "accounts": [
+        {
+          "name": "metadata",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Metadata account"
+        },
+        {
+          "name": "collectionAuthority",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "Collection Update authority"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "payer"
+        },
+        {
+          "name": "authorizationRules",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules account",
+          "optional": true
+        },
+        {
+          "name": "authorizationRulesProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token Authorization Rules Program",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "verifyArgs",
+          "type": {
+            "defined": "VerifyArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 52
+      }
     }
   ],
   "accounts": [
-    {
-      "name": "UseAuthorityRecord",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "Key"
-            }
-          },
-          {
-            "name": "allowedUses",
-            "type": "u64"
-          },
-          {
-            "name": "bump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
     {
       "name": "CollectionAuthorityRecord",
       "type": {
@@ -2035,6 +3512,171 @@
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "updateAuthority",
+            "type": {
+              "option": "publicKey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MetadataDelegateRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "delegate",
+            "type": "publicKey"
+          },
+          {
+            "name": "updateAuthority",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Edition",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "parent",
+            "type": "publicKey"
+          },
+          {
+            "name": "edition",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EditionMarker",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "ledger",
+            "type": {
+              "array": [
+                "u8",
+                31
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenOwnedEscrow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "baseToken",
+            "type": "publicKey"
+          },
+          {
+            "name": "authority",
+            "type": {
+              "defined": "EscrowAuthority"
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MasterEditionV2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "supply",
+            "type": "u64"
+          },
+          {
+            "name": "maxSupply",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MasterEditionV1",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "supply",
+            "type": "u64"
+          },
+          {
+            "name": "maxSupply",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "printingMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "oneTimePrintingAuthorizationMint",
+            "type": "publicKey"
           }
         ]
       }
@@ -2109,12 +3751,20 @@
                 "defined": "CollectionDetails"
               }
             }
+          },
+          {
+            "name": "programmableConfig",
+            "type": {
+              "option": {
+                "defined": "ProgrammableConfig"
+              }
+            }
           }
         ]
       }
     },
     {
-      "name": "MasterEditionV2",
+      "name": "TokenRecord",
       "type": {
         "kind": "struct",
         "fields": [
@@ -2125,68 +3775,34 @@
             }
           },
           {
-            "name": "supply",
-            "type": "u64"
+            "name": "bump",
+            "type": "u8"
           },
           {
-            "name": "maxSupply",
+            "name": "state",
             "type": {
-              "option": "u64"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "MasterEditionV1",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "Key"
+              "defined": "TokenState"
             }
           },
           {
-            "name": "supply",
-            "type": "u64"
-          },
-          {
-            "name": "maxSupply",
+            "name": "ruleSetRevision",
             "type": {
               "option": "u64"
             }
           },
           {
-            "name": "printingMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "oneTimePrintingAuthorizationMint",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Edition",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "key",
+            "name": "delegate",
             "type": {
-              "defined": "Key"
+              "option": "publicKey"
             }
           },
           {
-            "name": "parent",
-            "type": "publicKey"
-          },
-          {
-            "name": "edition",
-            "type": "u64"
+            "name": "delegateRole",
+            "type": {
+              "option": {
+                "defined": "TokenDelegateRole"
+              }
+            }
           }
         ]
       }
@@ -2264,7 +3880,7 @@
       }
     },
     {
-      "name": "EditionMarker",
+      "name": "UseAuthorityRecord",
       "type": {
         "kind": "struct",
         "fields": [
@@ -2275,16 +3891,94 @@
             }
           },
           {
-            "name": "ledger",
-            "type": {
-              "array": ["u8", 31]
-            }
+            "name": "allowedUses",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
           }
         ]
       }
     }
   ],
   "types": [
+    {
+      "name": "SetCollectionSizeArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "size",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateMetadataAccountArgsV2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "defined": "DataV2"
+            }
+          },
+          {
+            "name": "isMutable",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateMetadataAccountArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "defined": "Data"
+            }
+          },
+          {
+            "name": "isMutable",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateMetadataAccountArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "option": {
+                "defined": "Data"
+              }
+            }
+          },
+          {
+            "name": "updateAuthority",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "primarySaleHappened",
+            "type": {
+              "option": "bool"
+            }
+          }
+        ]
+      }
+    },
     {
       "name": "MintPrintingTokensViaTokenArgs",
       "type": {
@@ -2328,28 +4022,64 @@
       }
     },
     {
-      "name": "UpdateMetadataAccountArgs",
+      "name": "CreateMasterEditionArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "maxSupply",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintNewEditionFromMasterEditionViaTokenArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "edition",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferOutOfEscrowArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateMetadataAccountArgsV3",
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "data",
             "type": {
+              "defined": "DataV2"
+            }
+          },
+          {
+            "name": "isMutable",
+            "type": "bool"
+          },
+          {
+            "name": "collectionDetails",
+            "type": {
               "option": {
-                "defined": "Data"
+                "defined": "CollectionDetails"
               }
-            }
-          },
-          {
-            "name": "updateAuthority",
-            "type": {
-              "option": "publicKey"
-            }
-          },
-          {
-            "name": "primarySaleHappened",
-            "type": {
-              "option": "bool"
             }
           }
         ]
@@ -2390,94 +4120,6 @@
       }
     },
     {
-      "name": "CreateMetadataAccountArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "data",
-            "type": {
-              "defined": "Data"
-            }
-          },
-          {
-            "name": "isMutable",
-            "type": "bool"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CreateMetadataAccountArgsV2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "data",
-            "type": {
-              "defined": "DataV2"
-            }
-          },
-          {
-            "name": "isMutable",
-            "type": "bool"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CreateMetadataAccountArgsV3",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "data",
-            "type": {
-              "defined": "DataV2"
-            }
-          },
-          {
-            "name": "isMutable",
-            "type": "bool"
-          },
-          {
-            "name": "collectionDetails",
-            "type": {
-              "option": {
-                "defined": "CollectionDetails"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "CreateMasterEditionArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "maxSupply",
-            "type": {
-              "option": "u64"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "MintNewEditionFromMasterEditionViaTokenArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "edition",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
       "name": "ApproveUseAuthorityArgs",
       "type": {
         "kind": "struct",
@@ -2502,13 +4144,129 @@
       }
     },
     {
-      "name": "SetCollectionSizeArgs",
+      "name": "AuthorizationData",
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "size",
-            "type": "u64"
+            "name": "payload",
+            "type": {
+              "defined": "Payload"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "name": "uri",
+            "type": "string"
+          },
+          {
+            "name": "sellerFeeBasisPoints",
+            "type": "u16"
+          },
+          {
+            "name": "creators",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Creator"
+                }
+              }
+            }
+          },
+          {
+            "name": "primarySaleHappened",
+            "type": "bool"
+          },
+          {
+            "name": "isMutable",
+            "type": "bool"
+          },
+          {
+            "name": "tokenStandard",
+            "type": {
+              "defined": "TokenStandard"
+            }
+          },
+          {
+            "name": "collection",
+            "type": {
+              "option": {
+                "defined": "Collection"
+              }
+            }
+          },
+          {
+            "name": "uses",
+            "type": {
+              "option": {
+                "defined": "Uses"
+              }
+            }
+          },
+          {
+            "name": "collectionDetails",
+            "type": {
+              "option": {
+                "defined": "CollectionDetails"
+              }
+            }
+          },
+          {
+            "name": "ruleSet",
+            "type": {
+              "option": "publicKey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Collection",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "verified",
+            "type": "bool"
+          },
+          {
+            "name": "key",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Creator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "address",
+            "type": "publicKey"
+          },
+          {
+            "name": "verified",
+            "type": "bool"
+          },
+          {
+            "name": "share",
+            "type": "u8"
           }
         ]
       }
@@ -2598,64 +4356,6 @@
       }
     },
     {
-      "name": "Uses",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "useMethod",
-            "type": {
-              "defined": "UseMethod"
-            }
-          },
-          {
-            "name": "remaining",
-            "type": "u64"
-          },
-          {
-            "name": "total",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Collection",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "verified",
-            "type": "bool"
-          },
-          {
-            "name": "key",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Creator",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "address",
-            "type": "publicKey"
-          },
-          {
-            "name": "verified",
-            "type": "bool"
-          },
-          {
-            "name": "share",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
       "name": "Reservation",
       "type": {
         "kind": "struct",
@@ -2696,6 +4396,644 @@
       }
     },
     {
+      "name": "SeedsVec",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "seeds",
+            "type": {
+              "vec": "bytes"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LeafInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "leaf",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "proof",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Payload",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "map",
+            "type": {
+              "hashMap": [
+                {
+                  "defined": "PayloadKey"
+                },
+                {
+                  "defined": "PayloadType"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Uses",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "useMethod",
+            "type": {
+              "defined": "UseMethod"
+            }
+          },
+          {
+            "name": "remaining",
+            "type": "u64"
+          },
+          {
+            "name": "total",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BurnArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "VerifyArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "DelegateArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "CollectionV1",
+            "fields": [
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "SaleV1",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u64"
+              },
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "TransferV1",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u64"
+              },
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "UpdateV1",
+            "fields": [
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "UtilityV1",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u64"
+              },
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "StakingV1",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u64"
+              },
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "StandardV1",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevokeArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "CollectionV1"
+          },
+          {
+            "name": "SaleV1"
+          },
+          {
+            "name": "TransferV1"
+          },
+          {
+            "name": "UpdateV1"
+          },
+          {
+            "name": "UtilityV1"
+          },
+          {
+            "name": "StakingV1"
+          },
+          {
+            "name": "StandardV1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MetadataDelegateRole",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Authority"
+          },
+          {
+            "name": "Collection"
+          },
+          {
+            "name": "Use"
+          },
+          {
+            "name": "Update"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "asset_data",
+                "type": {
+                  "defined": "AssetData"
+                }
+              },
+              {
+                "name": "decimals",
+                "type": {
+                  "option": "u8"
+                }
+              },
+              {
+                "name": "print_supply",
+                "type": {
+                  "option": {
+                    "defined": "PrintSupply"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u64"
+              },
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u64"
+              },
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "new_update_authority",
+                "type": {
+                  "option": "publicKey"
+                }
+              },
+              {
+                "name": "data",
+                "type": {
+                  "option": {
+                    "defined": "Data"
+                  }
+                }
+              },
+              {
+                "name": "primary_sale_happened",
+                "type": {
+                  "option": "bool"
+                }
+              },
+              {
+                "name": "is_mutable",
+                "type": {
+                  "option": "bool"
+                }
+              },
+              {
+                "name": "collection",
+                "type": {
+                  "defined": "CollectionToggle"
+                }
+              },
+              {
+                "name": "collection_details",
+                "type": {
+                  "defined": "CollectionDetailsToggle"
+                }
+              },
+              {
+                "name": "uses",
+                "type": {
+                  "defined": "UsesToggle"
+                }
+              },
+              {
+                "name": "rule_set",
+                "type": {
+                  "defined": "RuleSetToggle"
+                }
+              },
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollectionToggle",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Clear"
+          },
+          {
+            "name": "Set",
+            "fields": [
+              {
+                "defined": "Collection"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "UsesToggle",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Clear"
+          },
+          {
+            "name": "Set",
+            "fields": [
+              {
+                "defined": "Uses"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollectionDetailsToggle",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Clear"
+          },
+          {
+            "name": "Set",
+            "fields": [
+              {
+                "defined": "CollectionDetails"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "RuleSetToggle",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Clear"
+          },
+          {
+            "name": "Set",
+            "fields": [
+              "publicKey"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrateArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "migration_type",
+                "type": {
+                  "defined": "MigrationType"
+                }
+              },
+              {
+                "name": "rule_set",
+                "type": {
+                  "option": "publicKey"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "UnlockArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "UseArgs",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "authorization_data",
+                "type": {
+                  "option": {
+                    "defined": "AuthorizationData"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenStandard",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NonFungible"
+          },
+          {
+            "name": "FungibleAsset"
+          },
+          {
+            "name": "Fungible"
+          },
+          {
+            "name": "NonFungibleEdition"
+          },
+          {
+            "name": "ProgrammableNonFungible"
+          }
+        ]
+      }
+    },
+    {
       "name": "Key",
       "type": {
         "kind": "enum",
@@ -2729,23 +5067,15 @@
           },
           {
             "name": "CollectionAuthorityRecord"
-          }
-        ]
-      }
-    },
-    {
-      "name": "UseMethod",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Burn"
           },
           {
-            "name": "Multiple"
+            "name": "TokenOwnedEscrow"
           },
           {
-            "name": "Single"
+            "name": "TokenRecord"
+          },
+          {
+            "name": "MetadataDelegate"
           }
         ]
       }
@@ -2768,21 +5098,207 @@
       }
     },
     {
-      "name": "TokenStandard",
+      "name": "EscrowAuthority",
       "type": {
         "kind": "enum",
         "variants": [
           {
-            "name": "NonFungible"
+            "name": "TokenOwner"
           },
           {
-            "name": "FungibleAsset"
+            "name": "Creator",
+            "fields": [
+              "publicKey"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PrintSupply",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Zero"
           },
           {
-            "name": "Fungible"
+            "name": "Limited",
+            "fields": [
+              "u64"
+            ]
           },
           {
-            "name": "NonFungibleEdition"
+            "name": "Unlimited"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgrammableConfig",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "rule_set",
+                "type": {
+                  "option": "publicKey"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrationType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "CollectionV1"
+          },
+          {
+            "name": "ProgrammableV1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Unlocked"
+          },
+          {
+            "name": "Locked"
+          },
+          {
+            "name": "Listed"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenDelegateRole",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Sale"
+          },
+          {
+            "name": "Transfer"
+          },
+          {
+            "name": "Utility"
+          },
+          {
+            "name": "Staking"
+          },
+          {
+            "name": "Standard"
+          },
+          {
+            "name": "Migration"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuthorityType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Metadata"
+          },
+          {
+            "name": "Delegate"
+          },
+          {
+            "name": "Holder"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PayloadType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Pubkey",
+            "fields": [
+              "publicKey"
+            ]
+          },
+          {
+            "name": "Seeds",
+            "fields": [
+              {
+                "defined": "SeedsVec"
+              }
+            ]
+          },
+          {
+            "name": "MerkleProof",
+            "fields": [
+              {
+                "defined": "LeafInfo"
+              }
+            ]
+          },
+          {
+            "name": "Number",
+            "fields": [
+              "u64"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PayloadKey",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Target"
+          },
+          {
+            "name": "Holder"
+          },
+          {
+            "name": "Authority"
+          },
+          {
+            "name": "Amount"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UseMethod",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Burn"
+          },
+          {
+            "name": "Multiple"
+          },
+          {
+            "name": "Single"
           }
         ]
       }
@@ -3162,7 +5678,7 @@
     {
       "code": 74,
       "name": "CollectionCannotBeVerifiedInThisInstruction",
-      "msg": "Cannont Verify Collection in this Instruction"
+      "msg": "Collection cannot be verified in this instruction"
     },
     {
       "code": 75,
@@ -3348,12 +5864,297 @@
       "code": 111,
       "name": "BorshDeserializationError",
       "msg": "Borsh Deserialization Error"
+    },
+    {
+      "code": 112,
+      "name": "CannotUpdateVerifiedCollection",
+      "msg": "Cannot update a verified collection in this command"
+    },
+    {
+      "code": 113,
+      "name": "CollectionMasterEditionAccountInvalid",
+      "msg": "Edition account doesnt match collection "
+    },
+    {
+      "code": 114,
+      "name": "AlreadyVerified",
+      "msg": "Item is already verified."
+    },
+    {
+      "code": 115,
+      "name": "AlreadyUnverified",
+      "msg": "Item is already unverified."
+    },
+    {
+      "code": 116,
+      "name": "NotAPrintEdition",
+      "msg": "This edition is not a Print Edition"
+    },
+    {
+      "code": 117,
+      "name": "InvalidMasterEdition",
+      "msg": "Invalid Master Edition"
+    },
+    {
+      "code": 118,
+      "name": "InvalidPrintEdition",
+      "msg": "Invalid Print Edition"
+    },
+    {
+      "code": 119,
+      "name": "InvalidEditionMarker",
+      "msg": "Invalid Edition Marker"
+    },
+    {
+      "code": 120,
+      "name": "ReservationListDeprecated",
+      "msg": "Reservation List is Deprecated"
+    },
+    {
+      "code": 121,
+      "name": "PrintEditionDoesNotMatchMasterEdition",
+      "msg": "Print Edition does not match Master Edition"
+    },
+    {
+      "code": 122,
+      "name": "EditionNumberGreaterThanMaxSupply",
+      "msg": "Edition Number greater than max supply"
+    },
+    {
+      "code": 123,
+      "name": "MustUnverify",
+      "msg": "Must unverify before migrating collections."
+    },
+    {
+      "code": 124,
+      "name": "InvalidEscrowBumpSeed",
+      "msg": "Invalid Escrow Account Bump Seed"
+    },
+    {
+      "code": 125,
+      "name": "MustBeEscrowAuthority",
+      "msg": "Must Escrow Authority"
+    },
+    {
+      "code": 126,
+      "name": "InvalidSystemProgram",
+      "msg": "Invalid System Program"
+    },
+    {
+      "code": 127,
+      "name": "MustBeNonFungible",
+      "msg": "Must be a Non Fungible Token"
+    },
+    {
+      "code": 128,
+      "name": "InsufficientTokens",
+      "msg": "Insufficient tokens for transfer"
+    },
+    {
+      "code": 129,
+      "name": "BorshSerializationError",
+      "msg": "Borsh Serialization Error"
+    },
+    {
+      "code": 130,
+      "name": "NoFreezeAuthoritySet",
+      "msg": "Cannot create NFT with no Freeze Authority."
+    },
+    {
+      "code": 131,
+      "name": "InvalidCollectionSizeChange",
+      "msg": "Invalid collection size change"
+    },
+    {
+      "code": 132,
+      "name": "InvalidBubblegumSigner",
+      "msg": "Invalid bubblegum signer"
+    },
+    {
+      "code": 133,
+      "name": "EscrowParentHasDelegate",
+      "msg": "Escrow parent cannot have a delegate"
+    },
+    {
+      "code": 134,
+      "name": "MintIsNotSigner",
+      "msg": "Mint needs to be signer to initialize the account"
+    },
+    {
+      "code": 135,
+      "name": "InvalidTokenStandard",
+      "msg": "Invalid token standard"
+    },
+    {
+      "code": 136,
+      "name": "InvalidMintForTokenStandard",
+      "msg": "Invalid mint account for specified token standard"
+    },
+    {
+      "code": 137,
+      "name": "InvalidAuthorizationRules",
+      "msg": "Invalid authorization rules account"
+    },
+    {
+      "code": 138,
+      "name": "MissingAuthorizationRules",
+      "msg": "Missing authorization rules account"
+    },
+    {
+      "code": 139,
+      "name": "MissingProgrammableConfig",
+      "msg": "Missing programmable configuration"
+    },
+    {
+      "code": 140,
+      "name": "InvalidProgrammableConfig",
+      "msg": "Invalid programmable configuration"
+    },
+    {
+      "code": 141,
+      "name": "DelegateAlreadyExists",
+      "msg": "Delegate already exists"
+    },
+    {
+      "code": 142,
+      "name": "DelegateNotFound",
+      "msg": "Delegate not found"
+    },
+    {
+      "code": 143,
+      "name": "MissingAccountInBuilder",
+      "msg": "Required account not set in instruction builder"
+    },
+    {
+      "code": 144,
+      "name": "MissingArgumentInBuilder",
+      "msg": "Required argument not set in instruction builder"
+    },
+    {
+      "code": 145,
+      "name": "FeatureNotSupported",
+      "msg": "Feature not supported currently"
+    },
+    {
+      "code": 146,
+      "name": "InvalidSystemWallet",
+      "msg": "Invalid system wallet"
+    },
+    {
+      "code": 147,
+      "name": "OnlySaleDelegateCanTransfer",
+      "msg": "Only the sale delegate can transfer while its set"
+    },
+    {
+      "code": 148,
+      "name": "MissingTokenAccount",
+      "msg": "Missing token account"
+    },
+    {
+      "code": 149,
+      "name": "MissingSplTokenProgram",
+      "msg": "Missing SPL token program"
+    },
+    {
+      "code": 150,
+      "name": "MissingAuthorizationRulesProgram",
+      "msg": "Missing authorization rules program"
+    },
+    {
+      "code": 151,
+      "name": "InvalidDelegateRoleForTransfer",
+      "msg": "Invalid delegate role for transfer"
+    },
+    {
+      "code": 152,
+      "name": "InvalidTransferAuthority",
+      "msg": "Invalid transfer authority"
+    },
+    {
+      "code": 153,
+      "name": "InstructionNotSupported",
+      "msg": "Instruction not supported for ProgrammableNonFungible assets"
+    },
+    {
+      "code": 154,
+      "name": "KeyMismatch",
+      "msg": "Public key does not match expected value"
+    },
+    {
+      "code": 155,
+      "name": "LockedToken",
+      "msg": "Token is locked"
+    },
+    {
+      "code": 156,
+      "name": "UnlockedToken",
+      "msg": "Token is unlocked"
+    },
+    {
+      "code": 157,
+      "name": "MissingDelegateRole",
+      "msg": "Missing delegate role"
+    },
+    {
+      "code": 158,
+      "name": "InvalidAuthorityType",
+      "msg": "Invalid authority type"
+    },
+    {
+      "code": 159,
+      "name": "MissingTokenRecord",
+      "msg": "Missing token record account"
+    },
+    {
+      "code": 160,
+      "name": "MintSupplyMustBeZero",
+      "msg": "Mint supply must be zero for programmable assets"
+    },
+    {
+      "code": 161,
+      "name": "DataIsEmptyOrZeroed",
+      "msg": "Data is empty or zeroed"
+    },
+    {
+      "code": 162,
+      "name": "MissingTokenOwnerAccount",
+      "msg": "Missing token owner"
+    },
+    {
+      "code": 163,
+      "name": "InvalidMasterEditionAccountLength",
+      "msg": "Master edition account has an invalid length"
+    },
+    {
+      "code": 164,
+      "name": "IncorrectTokenState",
+      "msg": "Incorrect token state"
+    },
+    {
+      "code": 165,
+      "name": "InvalidDelegateRole",
+      "msg": "Invalid delegate role"
+    },
+    {
+      "code": 166,
+      "name": "MissingPrintSupply",
+      "msg": "Print supply is required for non-fungibles"
+    },
+    {
+      "code": 167,
+      "name": "MissingMasterEditionAccount",
+      "msg": "Missing master edition account"
+    },
+    {
+      "code": 168,
+      "name": "AmountMustBeGreaterThanZero",
+      "msg": "Amount must be greater than zero"
     }
   ],
   "metadata": {
     "origin": "shank",
     "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-    "binaryVersion": "0.0.3",
-    "libVersion": "~0.0.2"
+    "binaryVersion": "0.0.11",
+    "libVersion": "0.0.11"
   }
 }


### PR DESCRIPTION
- Add support for default optional accounts and docs in IdlInstruction struct
- Add check for required optional accounts in RenderInstruction
- Add default optional account to IdlInstruction initializer in TestDataProvider

[Sources/Solita/Idl.swift]
- Add `defaultOptionalAccounts` and `docs` fields to `IdlInstruction` struct [Sources/Solita/RenderInstruction.swift]
- Add a check for required optional accounts
- Add an else clause to append a default optional account if `ix.defaultOptionalAccounts` is true [Tests/SolitaTests/Data/TestDataProvider.swift]
- Add `defaultOptionalAccounts` and `docs` parameters to the `IdlInstruction` initializer